### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -35,6 +38,9 @@ jobs:
     if: github.event_name == 'push'
     name: Deploy to Beta
     environment: beta
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v4
       - name: Deploy
@@ -51,6 +57,9 @@ jobs:
       matrix:
         environment: ['public', 'eus1', 'eus2']
     environment: ${{ matrix.environment }}
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v4
       - name: Deploy


### PR DESCRIPTION
Potential fix for [https://github.com/labelzoom/labelzoom-cf-api-proxy/security/code-scanning/4](https://github.com/labelzoom/labelzoom-cf-api-proxy/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for all jobs. Additionally, we will add job-specific `permissions` blocks for any jobs that require elevated permissions. Based on the workflow's steps:
- The `test` job requires `contents: read` to check out the repository and upload artifacts.
- The `beta-deploy` and `prod-deploy` jobs require `contents: read` and `deployments: write` to deploy to Cloudflare.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
