### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,12 +94,16 @@ async function proxyRequestToBackend(request: Request, url: URL, env: Env, reque
     // Force redirects to be relative because I couldn't get it to work in Spring Boot
     if (response.status === 301 || response.status === 302) {
         const locationHeader = response.headers.get('Location') ?? '';
-        if (locationHeader.includes('labelzoom.net/')) {
-            const url = new URL(locationHeader);
-
-            const newResponse = new Response(response.body, response);
-            newResponse.headers.set('Location', url.pathname + url.search);
-            return newResponse;
+        try {
+            const parsedUrl = new URL(locationHeader);
+            const allowedHosts = ['labelzoom.net', 'www.labelzoom.net'];
+            if (allowedHosts.includes(parsedUrl.host)) {
+                const newResponse = new Response(response.body, response);
+                newResponse.headers.set('Location', parsedUrl.pathname + parsedUrl.search);
+                return newResponse;
+            }
+        } catch (e) {
+            // Log or handle invalid URL parsing if necessary
         }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/labelzoom/labelzoom-cf-api-proxy/security/code-scanning/1](https://github.com/labelzoom/labelzoom-cf-api-proxy/security/code-scanning/1)

To fix the issue, we need to replace the substring check (`locationHeader.includes('labelzoom.net/')`) with a robust validation of the host component of the URL. This involves parsing the `locationHeader` into a `URL` object and verifying that its `host` matches an allowed host or subdomain. We will use a whitelist of allowed hosts (e.g., `labelzoom.net` and its subdomains) to ensure that only valid URLs are processed.

Steps to implement the fix:
1. Parse the `locationHeader` into a `URL` object.
2. Define a whitelist of allowed hosts (e.g., `labelzoom.net`, `www.labelzoom.net`).
3. Check if the `host` of the parsed URL matches any entry in the whitelist.
4. Proceed with modifying the `Location` header only if the host is valid.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
